### PR TITLE
Dialogue fixes and no dust collision

### DIFF
--- a/Dust Bunny/Assets/Scripts/Dialouge/DialogueManager.cs
+++ b/Dust Bunny/Assets/Scripts/Dialouge/DialogueManager.cs
@@ -56,9 +56,13 @@ public class DialogueManager : MonoBehaviour, IInteractable
 
     public void Interact()
     {
-        if(!_isStartedDialogue)
+        if (!_isStartedDialogue)
         {
             StartDialogue();
+        }
+        else if (!dialogueText.IsFinishedLine())
+        {
+            dialogueText.FinishLine();
         }
         else
         {

--- a/Dust Bunny/Assets/Scripts/Player/PlayerController.cs
+++ b/Dust Bunny/Assets/Scripts/Player/PlayerController.cs
@@ -360,9 +360,9 @@ public class PlayerController : MonoBehaviour
         if (other.gameObject.layer == _layerMaskValue)
         {
             _feetGrounded = true;
+            _lastCollision = other;
         }
 
-        _lastCollision = other;
     }
 
     private void OnTriggerExit2D(Collider2D other)
@@ -370,9 +370,8 @@ public class PlayerController : MonoBehaviour
         if (other.gameObject.layer == _layerMaskValue)
         {
             _feetGrounded = false;
+            _lastCollision = null;
         }
-
-        _lastCollision = null;
     }
 
 

--- a/Dust Bunny/Assets/Scripts/Player/PlayerController.cs
+++ b/Dust Bunny/Assets/Scripts/Player/PlayerController.cs
@@ -207,14 +207,8 @@ public class PlayerController : MonoBehaviour
 
     void Update()
     {
-        if(_isStopped)
-        {
-            if (Input.GetButtonDown("Interact"))
-            {
-                sendInteract();
-            }
-        }
-        if (_isDead || _isStopped) return;
+        if (_isDead) return;
+        
         gatherInput();
         //updateFriction(); //TODO: Ensure it doesnt flipflop
         updateDustSize();
@@ -266,11 +260,12 @@ public class PlayerController : MonoBehaviour
     private void gatherInput()
     {
         _input = new Vector2(Input.GetAxis("Horizontal"), Input.GetAxis("Vertical"));
-        if (Input.GetButtonDown("Jump"))
+        if(_isStopped) _input = Vector2.zero; //For animations, make sure it is actually stopped.
+        if (Input.GetButtonDown("Jump") && !_isStopped)
         {
             _doJump = true;
         }
-        if (Input.GetButtonDown("Dash"))
+        if (Input.GetButtonDown("Dash") && !_isStopped)
         {
             _doDash = true;
         }


### PR DESCRIPTION
- Fixed the "hopping" animation in spek while talking with someone.
- Pressing "E" now completes the dialogue instead of skipping it.
- Dust cloud no longer collides with Spek while being on the moving platform